### PR TITLE
[#230] Fix wrong order when call function

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -76,8 +76,8 @@ worker_build () {
 
 worker_build
 backend_build
-documentation_build
 frontend_build
+documentation_build
 
 #test-connection
 if ! dci run -T ci ./basic.sh; then


### PR DESCRIPTION
#230 Fixing wrong order when calling function, the frontend build should called before documentation build