### PR TITLE
[#261] Implementing JMP history feature

### DIFF
--- a/backend/alembic/versions/2023-01-19-03-57-07_974a3418ace8_create_jmp_history_table.py
+++ b/backend/alembic/versions/2023-01-19-03-57-07_974a3418ace8_create_jmp_history_table.py
@@ -1,0 +1,60 @@
+"""create jmp_history table
+
+Revision ID: 974a3418ace8
+Revises: f2f0ac233521
+Create Date: 2023-01-19 03:57:07.481110
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "974a3418ace8"
+down_revision = "f2f0ac233521"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "jmp_history",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("data", sa.Integer(), sa.ForeignKey("data.id")),
+        sa.Column("history", sa.Integer(), sa.ForeignKey("history.id")),
+        sa.Column("name", sa.String(length=254), nullable=False),
+        sa.Column("category", sa.String(length=254), nullable=False),
+        sa.Column(
+            "created",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+        ),
+        sa.Column(
+            "updated",
+            sa.DateTime(),
+            nullable=True,
+            onupdate=sa.text("(CURRENT_TIMESTAMP)"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["data"],
+            ["data.id"],
+            name="data_jmp_history_constraint",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["history"],
+            ["history.id"],
+            name="history_jmp_history_constraint",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(
+        op.f("ix_jmp_history_id"), "jmp_history", ["id"], unique=True
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_jmp_history_id"), table_name="jmp_history")
+    op.drop_table("jmp_history")

--- a/backend/db/crud_answer.py
+++ b/backend/db/crud_answer.py
@@ -42,14 +42,13 @@ def add_answer(
 
 
 def update_answer(
-    session: Session, answer: Answer, history: History, user: int,
+    session: Session, answer: Answer, user: int,
     type: QuestionType, value: Union[int, float, str, bool, List[str],
                                      List[int], List[float]]
 ) -> AnswerDict:
     answer.updated_by = user
     answer.updated = datetime.now()
     answer = append_value(answer, value, type)
-    session.add(history)
     session.commit()
     session.flush()
     session.refresh(answer)

--- a/backend/db/crud_jmp_history.py
+++ b/backend/db/crud_jmp_history.py
@@ -1,0 +1,34 @@
+from sqlalchemy.orm import Session
+from datetime import datetime
+from models.history import History
+from models.data import Data
+from models.jmp_history import JmpHistory
+from AkvoResponseGrouper.views import get_categories
+
+
+def add_history(
+    session: Session,
+    history: History,
+    data: Data,
+) -> None:
+    session.add(history)
+    session.commit()
+    session.flush()
+    session.refresh(history)
+
+    categories = get_categories(session=session, data=data.id, form=data.form)
+    histories = []
+    for c in categories:
+        histories.append(
+            {
+                "history": history.id,
+                "data": data.id,
+                "name": c.name,
+                "category": c.category,
+                "created": datetime.now(),
+                "updated": None,
+            }
+        )
+    session.bulk_insert_mappings(JmpHistory, histories)
+    session.commit()
+    session.flush()

--- a/backend/models/data.py
+++ b/backend/models/data.py
@@ -16,6 +16,7 @@ from .user import User
 from .answer import Answer
 from .administration import Administration
 from .views.view_data import ViewData
+from .jmp_history import JmpHistory
 from AkvoResponseGrouper.models import CategoryDict
 
 

--- a/backend/models/jmp_history.py
+++ b/backend/models/jmp_history.py
@@ -1,0 +1,87 @@
+# Please don't use **kwargs
+# Keep the code clean and CLEAR
+
+from datetime import datetime
+from typing_extensions import TypedDict
+from typing import Optional
+from pydantic import BaseModel
+from sqlalchemy import Column, Integer, String
+from sqlalchemy import ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from db.connection import Base
+
+
+class JmpHistoryDict(TypedDict):
+    id: int
+    history: int
+    data: int
+    name: str
+    category: str
+    created: datetime
+    updated: datetime
+
+
+class JmpHistory(Base):
+    __tablename__ = "jmp_history"
+    id = Column(Integer, primary_key=True, index=True, nullable=True)
+    history = Column(Integer, ForeignKey("history.id"))
+    data = Column(Integer, ForeignKey("data.id"))
+    name = Column(String, nullable=False)
+    category = Column(String, nullable=False)
+    created = Column(DateTime, nullable=True)
+    updated = Column(DateTime, nullable=True)
+    data_detail = relationship("Data", foreign_keys=[data])
+
+    def __init__(
+        self,
+        history: int,
+        created: datetime,
+        data: Optional[int] = None,
+        name: Optional[str] = None,
+        category: Optional[str] = None,
+        updated: Optional[datetime] = None,
+    ):
+        self.history = history
+        self.data = data
+        self.name = name
+        self.category = category
+        self.updated = updated
+        self.created = created
+
+    def __repr__(self) -> int:
+        return f"<JmpHistory {self.id}>"
+
+    @property
+    def serialize(self) -> JmpHistoryDict:
+        return {
+            "id": self.id,
+            "history": self.history,
+            "data": self.data,
+            "name": self.name,
+            "category": self.category,
+            "created": self.created,
+            "updated": self.updated,
+        }
+
+    @property
+    def simplified(self) -> TypedDict:
+        date = self.updated or self.created
+        return {
+            "date": date.strftime("%B %d, %Y"),
+            "data": self.data,
+            "name": self.name,
+            "category": self.category,
+        }
+
+
+class JmpHistoryBase(BaseModel):
+    id: int
+    history: int
+    data: int
+    name: Optional[str] = None
+    category: Optional[str] = None
+    created: Optional[datetime] = None
+    updated: Optional[datetime] = None
+
+    class Config:
+        orm_mode = True

--- a/backend/routes/data.py
+++ b/backend/routes/data.py
@@ -13,6 +13,7 @@ from db import crud_administration
 from db import crud_answer
 from db import crud_form
 from db import crud_user
+from db import crud_jmp_history
 from models.user import User, UserRole
 from models.answer import Answer, AnswerDict
 from models.question import QuestionType

--- a/backend/seeder/datapoint.py
+++ b/backend/seeder/datapoint.py
@@ -164,7 +164,7 @@ def record(answers, form, user):
     return data
 
 
-for table in ["data", "answer", "history"]:
+for table in ["data", "answer", "jmp_history", "history"]:
     action = truncate(session=session, table=table)
     print(action)
 

--- a/backend/source/wai-demo/category.json
+++ b/backend/source/wai-demo/category.json
@@ -422,6 +422,18 @@
                             "Bucket latrines",
                             "No toilets or latrines"
                         ]
+                    },
+                    {
+                        "question": 557690281,
+                        "options": [
+                            "No"
+                        ]
+                    },
+                    {
+                        "question": 557690277,
+                        "options": [
+                            "No"
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
- Add new migration: create jmp_history table.
- Create a new model called: JmpHistory.
- Create insert query in crud_jmp_history.
- Call crud_jmp_history.add_history after the draft updates datapoints is submitted in Admin view.