### PR TITLE
Feature/349 fix advanced filters query on map and chart

### DIFF
--- a/backend/db/crud_data.py
+++ b/backend/db/crud_data.py
@@ -119,7 +119,6 @@ def get_data(
     if administration:
         data = data.filter(Data.administration.in_(administration))
     count = data.count()
-    # TODO: getting the score
     # if no question order data by id desc
     data = data.order_by(desc(Data.id))
 

--- a/backend/routes/chart.py
+++ b/backend/routes/chart.py
@@ -143,8 +143,10 @@ def get_aggregated_jmp_chart_data(
     page: int = 1,
     perpage: int = 100,
     administration: Optional[int] = None,
+    q: Optional[List[str]] = Query(None),
     session: Session = Depends(get_session),
 ):
+    options = check_query(q) if q else None
     parent_administration = crud_administration.get_parent_administration(
         session=session
     )
@@ -159,9 +161,14 @@ def get_aggregated_jmp_chart_data(
             parent_administration = [
                 {"id": cd, "children": [cd]} for cd in fp[0]["children"]
             ]
+    adm_ids = (
+        [pa["id"] for pa in parent_administration] if administration else None
+    )
     paginated = get_data(
         session=session,
         form=form_id,
+        options=options,
+        administration=adm_ids,
         columns=[Data.id, Data.administration],
         skip=(perpage * (page - 1)),
         perpage=perpage,

--- a/backend/tests/test_15_1_charts.py
+++ b/backend/tests/test_15_1_charts.py
@@ -73,7 +73,7 @@ class TestChartsRoutes:
                 {"administration": 25, "child": []},
                 {"administration": 26, "child": []},
             ],
-            "total": 4,
+            "total": 2,
             "total_page": 1,
             "question": "sanitation",
             "scores": [],

--- a/frontend/src/components/PaginationApi.jsx
+++ b/frontend/src/components/PaginationApi.jsx
@@ -24,14 +24,16 @@ const PaginationApi = ({
   useEffect(() => {
     if (preload) {
       setPreload(false);
-      fetchAllPages().then((res) => {
-        if (callback) {
-          callback(res);
-        }
-      });
+      if (totalPages > 1) {
+        fetchAllPages().then((res) => {
+          if (callback) {
+            callback(res);
+          }
+        });
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [preload]);
+  }, [preload, totalPages]);
 
   return <React.Fragment />;
 };


### PR DESCRIPTION
## TODO/DONE

- [x] Fix query advance filter not triggered on MainMap
- [x] Re-introduce advanced filter query on JMP charts
Currently, q params don't exist on "charts:get_aggregated_jmp_chart_data"
https://github.com/akvo/wai-sdg-portal/blob/sandbox/backend/routes/chart.py#L139-L147


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204682106756545