### PR TITLE
Feature/432 add show empty value for jmp chart

### DIFF
--- a/frontend/src/chart/SplitBar.js
+++ b/frontend/src/chart/SplitBar.js
@@ -49,7 +49,7 @@ const SplitBar = (data, chartTitle, extra) => {
       );
       const percentage = val?.value ? (val.value / total) * 100 : 0;
       return {
-        name: val?.name || null,
+        name: val?.name || s.name,
         value: percentage.toFixed(2),
         count: val?.value || 0,
         itemStyle: { color: val?.color || s.color },

--- a/frontend/src/chart/custom/JMPBarStack.js
+++ b/frontend/src/chart/custom/JMPBarStack.js
@@ -8,6 +8,7 @@ import {
   NoData,
 } from '../chart-style.js';
 import uniq from 'lodash/uniq';
+import uniqBy from 'lodash/uniqBy';
 import isEmpty from 'lodash/isEmpty';
 import sortBy from 'lodash/sortBy';
 
@@ -23,11 +24,14 @@ const JMPBarStack = (data, chartTitle, extra) => {
     ['score']
   );
 
-  let stacked = data.find((d) => d?.stack?.length);
-  if (!stacked) {
+  let stacked = uniqBy(
+    data.flatMap((d) => d?.stack),
+    'name'
+  );
+  if (!stacked.length) {
     return NoData;
   }
-  stacked = stacked.stack.map((x) => ({ name: x.name, color: x.color }));
+  stacked = stacked.map((x) => ({ name: x.name, color: x.color }));
   const legends = stacked.map((s, si) => ({
     name: s.name,
     itemStyle: { color: s.color || Color.color[si] },

--- a/frontend/src/chart/index.js
+++ b/frontend/src/chart/index.js
@@ -38,7 +38,7 @@ const EchartWrapper = ({ emptyValueCheckboxSetting, option, height }) => {
       {emptyValueCheckboxSetting?.show && (
         <Col span={24}>
           <Checkbox
-            style={{ float: 'right', marginRight: '15px' }}
+            style={{ float: 'right', margin: '0 15px 20px 0' }}
             checked={emptyValueCheckboxSetting.checked}
             onChange={emptyValueCheckboxSetting.handleOnCheck}
           >

--- a/frontend/src/pages/main/MainChart.jsx
+++ b/frontend/src/pages/main/MainChart.jsx
@@ -11,6 +11,7 @@ import isEmpty from 'lodash/isEmpty';
 import takeRight from 'lodash/takeRight';
 import reverse from 'lodash/reverse';
 import sumBy from 'lodash/sumBy';
+import uniqBy from 'lodash/uniqBy';
 
 const levels = window.map_config?.shapeLevels?.length;
 const { mainText, chartText } = window.i18n;
@@ -43,6 +44,7 @@ const MainChart = ({ current, question }) => {
 
   // Get question option only to use on Main Chart
   const questionOption = question?.filter((q) => q.type === 'option');
+  const parentAdministration = administration.filter((adm) => !adm.parent);
 
   const chartQuestionOptions = useMemo(() => {
     return questionOption
@@ -119,6 +121,11 @@ const MainChart = ({ current, question }) => {
       data: dataFilterTmp,
     };
   }, [showEmptyValueOnStackedChart, chartData]);
+
+  const childAdministrationFromFilteredData = useMemo(() => {
+    let res = filteredChartData?.data?.flatMap((x) => x.stack);
+    return uniqBy(res, 'name');
+  }, [filteredChartData]);
 
   useEffect(() => {
     if (!isEmpty(selectedQuestion) || !isEmpty(selectedStack)) {
@@ -344,8 +351,12 @@ const MainChart = ({ current, question }) => {
                     (selectedStack?.id
                       ? (selectedStack?.type === 'administration') &
                         selectedAdministration.filter((x) => x).length
-                        ? administration.length * 50
-                        : 1000
+                        ? chartData?.data?.length *
+                          childAdministrationFromFilteredData.length *
+                          30
+                        : chartData?.data?.length *
+                          parentAdministration.length *
+                          40
                       : 150)
                   }
                   wrapper={false}

--- a/frontend/src/pages/main/MainChart.jsx
+++ b/frontend/src/pages/main/MainChart.jsx
@@ -361,10 +361,15 @@ const MainChart = ({ current, question }) => {
                   emptyValueCheckboxSetting={{
                     show: true,
                     checked: showEmptyValueOnStackedChart,
-                    handleOnCheck: () =>
+                    handleOnCheck: () => {
+                      setLoadingChartData(true);
                       setShowEmptyValueOnStackedChart(
                         !showEmptyValueOnStackedChart
-                      ),
+                      );
+                      setTimeout(() => {
+                        setLoadingChartData(false);
+                      }, 500);
+                    },
                   }}
                 />
               ) : loadingChartData ? (

--- a/frontend/src/pages/main/MainChart.jsx
+++ b/frontend/src/pages/main/MainChart.jsx
@@ -123,7 +123,7 @@ const MainChart = ({ current, question }) => {
   }, [showEmptyValueOnStackedChart, chartData]);
 
   const childAdministrationFromFilteredData = useMemo(() => {
-    let res = filteredChartData?.data?.flatMap((x) => x.stack);
+    const res = filteredChartData?.data?.flatMap((x) => x.stack);
     return uniqBy(res, 'name');
   }, [filteredChartData]);
 
@@ -349,14 +349,17 @@ const MainChart = ({ current, question }) => {
                       ? 500
                       : chartData?.data?.length * 50) +
                     (selectedStack?.id
-                      ? (selectedStack?.type === 'administration') &
-                        selectedAdministration.filter((x) => x).length
-                        ? chartData?.data?.length *
-                          childAdministrationFromFilteredData.length *
-                          30
+                      ? selectedStack?.type === 'administration'
+                        ? selectedAdministration.filter((x) => x).length
+                          ? chartData?.data?.length *
+                            childAdministrationFromFilteredData.length *
+                            30
+                          : chartData?.data?.length *
+                            parentAdministration.length *
+                            40
                         : chartData?.data?.length *
-                          parentAdministration.length *
-                          40
+                          selectedStack?.option?.length *
+                          30
                       : 150)
                   }
                   wrapper={false}

--- a/frontend/src/pages/main/tabs/__tests__/StackBarChart.test.js
+++ b/frontend/src/pages/main/tabs/__tests__/StackBarChart.test.js
@@ -129,9 +129,16 @@ jest.mock('../../../../util/api', () => {
   };
 });
 
+const mockHandleOnCheck = jest.fn();
 const mockChartComponent = jest.fn();
 // eslint-disable-next-line react/display-name
 jest.mock('../../../../chart', () => (props) => {
+  if (props?.emptyValueCheckboxSetting) {
+    // Modify emptyValueCheckboxSetting for testing purposes
+    props.emptyValueCheckboxSetting.show = true;
+    props.emptyValueCheckboxSetting.checked = false;
+    props.emptyValueCheckboxSetting.handleOnCheck = mockHandleOnCheck;
+  }
   mockChartComponent(props);
   return <mock-chartComponent />;
 });
@@ -181,13 +188,6 @@ describe('StackBarChart', () => {
               score: 8.071428571428571,
               stack: [
                 {
-                  color: '#ffda46',
-                  id: 0,
-                  name: 'No service',
-                  order: 1,
-                  value: 0,
-                },
-                {
                   color: '#fff176',
                   id: 1,
                   name: 'Limited',
@@ -210,13 +210,6 @@ describe('StackBarChart', () => {
               score: 7.551470588235295,
               stack: [
                 {
-                  color: '#ffda46',
-                  id: 0,
-                  name: 'No service',
-                  order: 1,
-                  value: 0,
-                },
-                {
                   color: '#fff176',
                   id: 1,
                   name: 'Limited',
@@ -233,7 +226,14 @@ describe('StackBarChart', () => {
               ],
             },
           ],
-          extra: { selectedAdministration: null },
+          emptyValueCheckboxSetting: {
+            checked: false,
+            handleOnCheck: mockHandleOnCheck,
+            show: true,
+          },
+          extra: {
+            selectedAdministration: null,
+          },
           height: 320,
           subTitle: '',
           title: '',


### PR DESCRIPTION
TODO / DONE

---

- #432 
- [x] Enable show empty value feature on JMP chart
- [x] Filter JMP chart data by show empty value feature
- [x] Refine main chart (stacked chart) data when check/uncheck show empty value by `setLoading` status to true the render the filtered chart data


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205705383225539