### PR TITLE
Explore fix for chart spacing

### DIFF
--- a/frontend/src/chart/Bar.js
+++ b/frontend/src/chart/Bar.js
@@ -28,6 +28,7 @@ const Bar = (data, chartTitle, extra) => {
   data = sortBy(data, 'order');
   data = data.map((x) => ({ ...x, percentage: (x.value / total) * 100 }));
   const dataSource = data.map((x) => x.name);
+  const gridHeight = dataSource.length * 60;
   const option = {
     ...Color,
     title: {
@@ -44,6 +45,7 @@ const Bar = (data, chartTitle, extra) => {
         color: '#222',
         ...TextStyle,
       },
+      height: gridHeight,
     },
     tooltip: {
       show: true,

--- a/frontend/src/chart/SplitBar.js
+++ b/frontend/src/chart/SplitBar.js
@@ -79,7 +79,7 @@ const SplitBar = (data, chartTitle, extra) => {
       data: temp,
     };
   });
-
+  const gridHeight = data?.length * 35;
   const option = {
     ...Color,
     title: {
@@ -103,6 +103,7 @@ const SplitBar = (data, chartTitle, extra) => {
         color: '#222',
         ...TextStyle,
       },
+      height: gridHeight,
     },
     tooltip: {
       trigger: 'axis',

--- a/frontend/src/chart/custom/JMPBarStack.js
+++ b/frontend/src/chart/custom/JMPBarStack.js
@@ -61,6 +61,7 @@ const JMPBarStack = (data, chartTitle, extra) => {
       data: temp,
     };
   });
+  const gridHeight = data.length * 60;
   const option = {
     ...Color,
     title: {
@@ -83,6 +84,7 @@ const JMPBarStack = (data, chartTitle, extra) => {
         color: '#222',
         ...TextStyle,
       },
+      height: gridHeight,
     },
     tooltip: {
       trigger: 'axis',

--- a/frontend/src/pages/main/MainChart.jsx
+++ b/frontend/src/pages/main/MainChart.jsx
@@ -345,19 +345,19 @@ const MainChart = ({ current, question }) => {
                   type={filteredChartData.type}
                   data={filteredChartData.data}
                   height={
-                    (chartData?.data?.length <= 5
+                    (filteredChartData?.data?.length <= 5
                       ? 500
-                      : chartData?.data?.length * 50) +
+                      : filteredChartData?.data?.length * 60) +
                     (selectedStack?.id
                       ? selectedStack?.type === 'administration'
                         ? selectedAdministration.filter((x) => x).length
-                          ? chartData?.data?.length *
+                          ? filteredChartData?.data?.length *
                             childAdministrationFromFilteredData.length *
                             30
-                          : chartData?.data?.length *
+                          : filteredChartData?.data?.length *
                             parentAdministration.length *
                             40
-                        : chartData?.data?.length *
+                        : filteredChartData?.data?.length *
                           selectedStack?.option?.length *
                           30
                       : 150)

--- a/frontend/src/pages/main/tabs/StackBarChart.jsx
+++ b/frontend/src/pages/main/tabs/StackBarChart.jsx
@@ -40,7 +40,7 @@ const getAdmScores = (chartScores, data) => {
         (statusValues[administration][option] / totalPercent) * 100;
       const score = chartScores[option] || 0;
       scoreValues[administration].push((score * percent) / 100);
-      statusPercentages[administration][option] = percent;
+      statusPercentages[administration][option] = percent || 0;
     }
   }
   return {
@@ -51,7 +51,6 @@ const getAdmScores = (chartScores, data) => {
 
 const StackBarChart = ({
   apiUrl,
-  height,
   chartScores,
   totalPages,
   data,
@@ -98,6 +97,8 @@ const StackBarChart = ({
     return filterTmp;
   }, [showEmptyValueChart, chartValues]);
 
+  const height = filteredChartValues.length * 60;
+
   return (
     <div className="jmp-chart-container">
       <PaginationApi
@@ -118,7 +119,7 @@ const StackBarChart = ({
             type={'JMP-BARSTACK'}
             data={filteredChartValues}
             wrapper={false}
-            height={height < 320 ? 320 : height}
+            height={height}
             extra={{
               selectedAdministration,
             }}

--- a/frontend/src/pages/main/tabs/TabJMP.jsx
+++ b/frontend/src/pages/main/tabs/TabJMP.jsx
@@ -147,8 +147,6 @@ const TabJMP = ({ formId, chartList, show }) => {
       ) : (
         <Col span={24}>
           {chartData?.map((c, ci) => {
-            const height =
-              (c?.data?.filter((x) => x?.stack?.length)?.length || 0) * 50;
             return [
               <Col
                 key={`jmp-chart-title-${ci}`}
@@ -162,7 +160,7 @@ const TabJMP = ({ formId, chartList, show }) => {
                 span={24}
               >
                 <StackBarChart
-                  {...{ ...c, height, chartScores }}
+                  {...{ ...c, chartScores }}
                   apiUrl={getApiUrl(c.question)}
                 />
               </Col>,


### PR DESCRIPTION
## TODO/DONE

- [ ] Fix chart spacing in TabJMP
- [ ] Fix chart spacing in "Bar chart for any indicator" section


## Bug reproduce
1. Use instance `wai-uganda`
2. Import household data from cleaned data/WAI_Uganda_baseline_household_CLEANED (1).xlsx]
3. Go to [JMP Households](http://localhost:3000/data/households)
4. Filter JMP chart by district: Agago, sub-county: Lira Palwo
5. [You will get something like this](https://akvo.slack.com/archives/C04RD86DWRW/p1700226918549849)